### PR TITLE
Add responsive Next.js todo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Node modules
+node_modules/
+# Production build
+.next/
+out/
+# Logs
+npm-debug.log*
+.yarn-debug.log*
+.yarn-error.log*
+# Environment variables
+.env.local
+.env.*.local
+
+# Mac/Linux/Windows
+.DS_Store
+Thumbs.db
+
+# Git
+.git

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# codex-todo
+# Codex Todo
+
+This is a small Next.js todo application. The project is configured to export static files so it can be hosted on GitHub Pages.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build & Export
+
+```bash
+npm run build
+```
+
+The static site will be generated in the `out/` directory.
+You can set `NEXT_PUBLIC_BASE_PATH` before building if you need to deploy to a subpath (e.g., `/codex-todo`).
+
+
+## Deploy to GitHub Pages
+
+Make sure the repository has a `gh-pages` branch and run:
+
+```bash
+npm run deploy
+```
+
+This uses the `gh-pages` package to publish the contents of the `out/` folder.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  reactStrictMode: true,
+  assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || ""
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "codex-todo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "deploy": "gh-pages -d out"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "gh-pages": "5.0.0",
+    "typescript": "5.4.2"
+  }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import styles from '../styles/Home.module.css';
+
+interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+export default function Home() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [text, setText] = useState('');
+
+  const addTodo = () => {
+    if (!text.trim()) return;
+    setTodos([...todos, { id: Date.now(), text, completed: false }]);
+    setText('');
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos(todos.map(t => t.id === id ? { ...t, completed: !t.completed } : t));
+  };
+
+  const deleteTodo = (id: number) => {
+    setTodos(todos.filter(t => t.id !== id));
+  };
+
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>Codex Todo</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <main className={styles.main}>
+        <h1 className={styles.title}>Todo List</h1>
+        <div className={styles.inputRow}>
+          <input
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="Add a task"
+            className={styles.input}
+          />
+          <button onClick={addTodo} className={styles.addBtn}>Add</button>
+        </div>
+        <ul className={styles.list}>
+          {todos.map(todo => (
+            <li key={todo.id} className={styles.item}>
+              <label className={todo.completed ? styles.completed : ''}>
+                <input
+                  type="checkbox"
+                  checked={todo.completed}
+                  onChange={() => toggleTodo(todo.id)}
+                />
+                {todo.text}
+              </label>
+              <button onClick={() => deleteTodo(todo.id)} className={styles.delBtn}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -1,0 +1,75 @@
+.container {
+  min-height: 100vh;
+  padding: 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.main {
+  padding: 5rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  max-width: 600px;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.5rem;
+  text-align: center;
+}
+
+.inputRow {
+  display: flex;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.addBtn {
+  padding: 0.5rem 1rem;
+  margin-left: 0.5rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.completed {
+  text-decoration: line-through;
+  color: #999;
+}
+
+.delBtn {
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .inputRow {
+    flex-direction: column;
+  }
+  .addBtn {
+    margin: 0.5rem 0 0;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,11 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create Next.js todo application
- configure static export for GitHub Pages
- document build and deployment steps
- ignore build artifacts

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68430f4a0fa88323ac28e8cbc864f021