### PR TITLE
Add dark mode option

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 
@@ -11,6 +11,15 @@ interface Todo {
 export default function Home() {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [text, setText] = useState('');
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    setDarkMode(localStorage.getItem('darkMode') === 'true');
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('darkMode', darkMode.toString());
+  }, [darkMode]);
 
   const addTodo = () => {
     if (!text.trim()) return;
@@ -27,13 +36,19 @@ export default function Home() {
   };
 
   return (
-    <div className={styles.container}>
+    <div className={`${styles.container} ${darkMode ? styles.dark : ''}`}>
       <Head>
         <title>Codex Todo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <main className={styles.main}>
         <h1 className={styles.title}>Todo List</h1>
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          className={styles.toggleDark}
+        >
+          {darkMode ? 'Light Mode' : 'Dark Mode'}
+        </button>
         <div className={styles.inputRow}>
           <input
             value={text}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -73,3 +73,26 @@
     margin: 0.5rem 0 0;
   }
 }
+
+.toggleDark {
+  margin-top: 1rem;
+}
+
+.dark {
+  background-color: #333;
+  color: #fff;
+}
+
+.dark .item {
+  border-bottom: 1px solid #555;
+}
+
+.dark input {
+  background-color: #555;
+  color: #fff;
+}
+
+.dark button {
+  background-color: #666;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add dark mode state and toggle button
- style components for dark mode

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684311c7c8908323b986bbbcdaddbc96